### PR TITLE
fix hint for "demo" so it works with default Plover

### DIFF
--- a/plover-translations.js
+++ b/plover-translations.js
@@ -4164,7 +4164,7 @@ TypeJig.Translations.Plover = {
 	"demean": "DMEEN",
 	"demeanor": "DMEEN/O*R",
 	"dementia": "DMEN/SHA",
-	"demo": "DOIM",
+	"demo": "DEM/JO",
 	"demographic": "DEM/GRAFK",
 	"demographics": "DEM/GRAFKS",
 	"demon": "DEEM/O*N",


### PR DESCRIPTION
I found another one where Mirabai's most used brief is not in Plover's default dictionary.

I like ``DMO`` or ``DMOE`` best, but those are not in the default dictionary either.

I'll suggest that all three be added, but in the mean time, I think "DEM/JO" is best.