### PR TITLE
Don't blank answer before counting chars (fix WPM)

### DIFF
--- a/type-jig.js
+++ b/type-jig.js
@@ -190,7 +190,6 @@ TypeJig.prototype.addError = function(word, error) {
 TypeJig.prototype.endExercise = function(seconds) {
 	if(this.running) this.running = false;
 	else return;
-	this.ans.firstChild.nodeValue = '';
 	if(document.activeElement != document.body) document.activeElement.blur();
 	this.ans.setAttribute('contenteditable', false);
 	this.ans.className = '';


### PR DESCRIPTION
A few lines after this line of code that blanked out the answer text, is a line
that checks how many characters it contains, which figures into the WPM
calculation.

This line (removed by this patch) was making that calculation come out wrong.
Also it appears to be redundant, since the entire contents of this element are
replaced in the last line in this function.

I found this bug because I noticed that _very_ short drills (20 characters in my most recent case) were labeled as 0 WPM.