### PR TITLE
fix gutenberg hints <label>, cleanup

### DIFF
--- a/form.html
+++ b/form.html
@@ -29,7 +29,7 @@
 			<br>
 
 			<div name="hints">
-				<input type="checkbox" name="hints" value="1" id="ngslHints" checked><label for="ngslHints">Show hints</label>
+				<label><input type="checkbox" name="hints" value="1" checked>Show hints</label>
 			</div>
 
 			<button>Start Drill &rarr;</button>
@@ -51,7 +51,7 @@
 			<br>
 
 			<div name="hints">
-				<input type="checkbox" name="hints" value="1" id="ngslHints" checked><label for="ngslHints">Show hints</label>
+				<label><input type="checkbox" name="hints" value="1" id="ngslHints" checked>Show hints</label>
 			</div>
 
 			<button>Start Drill &rarr;</button>
@@ -71,7 +71,7 @@
 			<br>
 
 			<div name="hints">
-				<input type="checkbox" name="hints" value="1" id="cvcHints" checked><label for="cvcHints">Show hints</label>
+				<label><input type="checkbox" name="hints" value="1" checked>Show hints</label>
 			</div>
 
 			<button>Start Drill &rarr;</button>
@@ -91,7 +91,7 @@
 			<br>
 
 			<div name="hints">
-				<input type="checkbox" name="hints" value="1" id="numberHints" checked><label for="numberHints">Show hints</label>
+				<label><input type="checkbox" name="hints" value="1" checked>Show hints</label>
 			</div>
 
 			<button>Start Drill &rarr;</button>


### PR DESCRIPTION
clicking the "show hints" caption on the gutenberg part of the form was toggling the wrong hints checkbox.

Also, code cleanup... you don't need "for" attribute if you put the ``<input>`` inside the ``<label>``