### PR TITLE
word drill form: 25-word increments fixed

### DIFF
--- a/form.html
+++ b/form.html
@@ -25,7 +25,7 @@
 			Drill
 			<input type="number" name="count" value="100" min="25" max="1000" step="25">
 			words starting at rank
-			<input type="number" name="first" value="0" min="0" max="1100" step="100">
+			<input type="number" name="first" value="0" min="0" max="1100" step="25">
 			<br>
 
 			<div name="hints">


### PR DESCRIPTION
The two input boxes had different increments, which made it so you can't
practice words in 25-word increments, because the starting word was locked to
multiples of 100.

With this patch, you can practice the 2nd 25 words (words 25-50), etc.