### PR TITLE
Fix "Back to Menu" link for Gutenberg drills

### DIFF
--- a/util.js
+++ b/util.js
@@ -25,7 +25,7 @@ function setExercise(name, exercise, hints) {
 	document.title = name + ' - ' + document.title;
 
 	var back = document.getElementById('back');
-	back.href = document.location.href.split('?')[0];
+	back.href = 'form.html';
 	var again = document.getElementById('again');
 	again.href = document.location.href;
 


### PR DESCRIPTION
I'm not sure what the best way of doing this is, so let me know if there's something else I should be doing.