### PR TITLE
Learn plover: Persist form state

### DIFF
--- a/learn-plover.html
+++ b/learn-plover.html
@@ -61,6 +61,11 @@ window.onload = function() {
 			drill.appendChild(option);
 		}
 		drill.focus();
+
+		loadFormState(form);
+		form.addEventListener("submit", function(){
+		    saveFormState(form);
+		});
 	} else {
 		displayOnly('lesson');
 		var fields = parseQueryString();
@@ -131,6 +136,46 @@ function parseQueryString() {
 		else vars[name] = value;
 	}
 	return vars;
+}
+
+function saveFormState(form) {
+    save({
+        drill: form.drill.value,
+        hints: form.hints.checked,
+        type: form.type.value,
+        timeLimit: form.timeLimit.value,
+    });
+}
+
+function loadFormState(form) {
+    var loaded = load();
+    if (loaded.drill) {
+        form.drill.value = loaded.drill;
+    }
+    form.hints.checked = loaded.hints;
+    form.type.value = loaded.type;
+    if (loaded.timeLimit) {
+        form.timeLimit.value = loaded.timeLimit;
+    }
+}
+
+var LOCAL_STORAGE_KEY = "learn-plover-form";
+
+function save(obj) {
+    try {
+        localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(obj));
+    } catch (e) {
+        console.error(e);
+    }
+}
+
+function load() {
+    try {
+        return JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY)) || {};
+    } catch (e) {
+        console.error(e);
+        return {};
+    }
 }
 </script>
 </body>

--- a/learn-plover.html
+++ b/learn-plover.html
@@ -15,15 +15,17 @@
 <div class="wrapper">
 	<div id="form">
 		<h1>Learn Plover Exercises</h1>
-		<div class="form-section"><form id="selectDrill">
-			<ul style="list-style-type: none">
-				<li><select name="drill"></select></li>
-				<li><label><input name="hints" type="checkbox" value="yes" checked> Show hints?</label></li>
-				<li><label><input id="randomly" name="type" type="radio" value="randomly"> Randomly</label> for <input name="timeLimit" type="text" size="2", value="10" oninput="selectRandomly()"> minutes.</li>
-				<li><label><input id="ordered" name="type" type="radio" value="once" checked> Once in order.</label></li>
-				<li><label><input id="shuffled" name="type" type="radio" value="shuffled"> Once in random order.</label></li>
-				<li><input type="submit" value="Go"></li>
-			</ul>
+		<div class="form-section">
+			<form id="selectDrill">
+				<ul style="list-style-type: none">
+					<li><select name="drill"></select></li>
+					<li><label><input name="hints" type="checkbox" value="yes" checked> Show hints?</label></li>
+					<li><label><input id="randomly" name="type" type="radio" value="randomly"> Randomly</label> for <input name="timeLimit" type="text" size="2", value="10" oninput="selectRandomly()"> minutes.</li>
+					<li><label><input id="ordered" name="type" type="radio" value="once" checked> Once in order.</label></li>
+					<li><label><input id="shuffled" name="type" type="radio" value="shuffled"> Once in random order.</label></li>
+					<li><input type="submit" value="Go"></li>
+				</ul>
+			</form>
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
# Problem
When a user come back from Learn Plover drill page to the selection page, the selection of drill is reset and the first drill is always chosen. It's not convenient.

# Solution
This change persists form state like drill, hints, type and timeLimit to localStorage if it's available and restore on page load. This fixes the problem above and also it can restore your previous setting any time in future.

# Demo

https://na2hiro.github.io/steno-jig/learn-plover.html