### PR TITLE
type-jig: Navigation by stroke

### DIFF
--- a/form.html
+++ b/form.html
@@ -137,8 +137,8 @@
 	<p id="clock" class="clock"></p>
 
 	<p class="center">
-		<a id="back">&larr; Back to Menu</a>
-		<a id="again">&#8634; Restart</a>
+		<a id="back">&larr; Back to Menu (STPH-R)</a>
+		<a id="again">&#8634; Restart (R-R, R*R)</a>
 	</p>
 
 	<p id="error-log"></p>

--- a/form.html
+++ b/form.html
@@ -136,9 +136,9 @@
 
 	<p id="clock" class="clock"></p>
 
-	<p class="center">
-		<a id="back">&larr; Back to Menu (STPH-R)</a>
-		<a id="again">&#8634; Restart (R-R, R*R)</a>
+	<p class="navigation center">
+		<a id="back" title="LeftArrow">&larr; Back to Menu <span class="shortcutkey">(LeftArrow)</span></a>
+		<a id="again" title="Enter">&#8634; Restart <span class="shortcutkey">(Enter)</span></a>
 	</p>
 
 	<p id="error-log"></p>

--- a/gutenberg.html
+++ b/gutenberg.html
@@ -23,12 +23,10 @@
 
 	<p id="clock" class="clock"></p>
 
-	<p class="center">
-		<a id="back">&larr; Back to Menu (STPH-R)</a>
-		&nbsp;
-		<a id="again">&#8634; Repeat Drill (R-R, R*R)</a>
-		&nbsp;
-		<a id="new">&rarr; New Drill (STPH-G)</a>
+	<p class="navigation center">
+		<a id="back" title="LeftArrow">&larr; Back to Menu <span class="shortcutkey">(LeftArrow)</span></a>
+		<a id="again" title="Enter">&#8634; Repeat Drill <span class="shortcutkey">(Enter)</span></a>
+		<a id="new" title="RightArrow">&rarr; New Drill <span class="shortcutkey">(RightArrow)</span></a>
 	</p>
 
 	<p id="error-log"></p>

--- a/gutenberg.html
+++ b/gutenberg.html
@@ -24,11 +24,11 @@
 	<p id="clock" class="clock"></p>
 
 	<p class="center">
-		<a id="back">&larr; Back to Menu</a>
+		<a id="back">&larr; Back to Menu (STPH-R)</a>
 		&nbsp;
-		<a id="again">&#8634; Repeat Drill</a>
+		<a id="again">&#8634; Repeat Drill (R-R, R*R)</a>
 		&nbsp;
-		<a id="new">&rarr; New Drill</a>
+		<a id="new">&rarr; New Drill (STPH-G)</a>
 	</p>
 
 	<p id="error-log"></p>

--- a/learn-plover.html
+++ b/learn-plover.html
@@ -38,9 +38,9 @@
 
 	<p id="clock" class="clock"></p>
 
-	<p class="center">
-		<a id="back">&larr; Back to Menu (STPH-R)</a>
-		<a id="again">&#8634; Restart (R-R, R*R)</a>
+	<p class="navigation center">
+		<a id="back" title="LeftArrow">&larr; Back to Menu <span class="shortcutkey">(LeftArrow)</span></a>
+		<a id="again" title="Enter">&#8634; Restart <span class="shortcutkey">(Enter)</span></a>
 	</p>
 
 	<p id="error-log"></p>

--- a/learn-plover.html
+++ b/learn-plover.html
@@ -39,8 +39,8 @@
 	<p id="clock" class="clock"></p>
 
 	<p class="center">
-		<a id="back">&larr; Back to Menu</a>
-		<a id="again">&#8634; Restart</a>
+		<a id="back">&larr; Back to Menu (STPH-R)</a>
+		<a id="again">&#8634; Restart (R-R, R*R)</a>
 	</p>
 
 	<p id="error-log"></p>

--- a/style.css
+++ b/style.css
@@ -93,6 +93,17 @@ a, a:visited {
 
 .center { text-align: center; }
 
+/* Navigation */
+.navigation a {
+    text-decoration: none;
+}
+.navigation a:not(:last-child) {
+    margin-right: 30px;
+}
+.shortcutkey {
+    font-size: small;
+    vertical-align: middle;
+}
 
 /* Configure these to tune the stroke display to your liking. */
 

--- a/type-jig.js
+++ b/type-jig.js
@@ -22,7 +22,7 @@ function TypeJig(exercise, output, input, clock, hint) {
 	if(this.hint && this.hint.update) this.hint.update(this.lookahead[0] || '');
 	this.scrollTo = this.out.firstChild;
 	bindEvent(input, 'input', this.answerChanged.bind(this));
-	bindEvent(input, 'keydown', this.keyDown.bind(this));
+	bindEvent(document.body, 'keydown', this.keyDown.bind(this));
 	input.focus();
 	window.scroll(0, scrollOffset(output));
 }

--- a/type-jig.js
+++ b/type-jig.js
@@ -22,6 +22,7 @@ function TypeJig(exercise, output, input, clock, hint) {
 	if(this.hint && this.hint.update) this.hint.update(this.lookahead[0] || '');
 	this.scrollTo = this.out.firstChild;
 	bindEvent(input, 'input', this.answerChanged.bind(this));
+	bindEvent(input, 'keydown', this.keyDown.bind(this));
 	input.focus();
 	window.scroll(0, scrollOffset(output));
 }
@@ -147,6 +148,27 @@ TypeJig.prototype.answerChanged = function() {
 		this.hint.update(this.lookahead[this.nextWordIndex]);
 	}
 }
+
+TypeJig.prototype.keyDown = function (e) {
+    var id;
+    switch (e.key) {
+        case "Enter":
+            id = "again";
+            break;
+        case "ArrowLeft":
+            id = "back";
+            break;
+        case "ArrowRight":
+            id = "new";
+            break;
+    }
+    if (id) {
+        var link = document.getElementById(id);
+        if (link) {
+            link.click();
+        }
+    }
+};
 
 // Ensure that `words` (and `out`) contain at least `n` words (unless
 // we're at the end of the exercise).


### PR DESCRIPTION
# Improvement

Added navigation by keystrokes on the drill page. This makes learn plover drill fully navigable by steno keyboards.

* Enter: restart
* Left: go back
* Right: new drill (only in `gutenberg.html`)

# Demo
https://na2hiro.github.io/steno-jig/learn-plover.html?drill=Diphthong+Chords&timeLimit=10&type=shuffled