### PR TITLE
Fix reload bugs

### DIFF
--- a/form.html
+++ b/form.html
@@ -150,6 +150,7 @@
 	<div id="drill-content">
 		<div id="answer"></div>
 		<div id="exercise"></div>
+		<div id="results"></div>
 	</div>
 
 	<div id="nav">

--- a/gutenberg.html
+++ b/gutenberg.html
@@ -18,6 +18,7 @@
 	<div id="drill-content">
 		<div id="answer"></div>
 		<div id="exercise"></div>
+		<div id="results"></div>
 	</div>
 
 	<div id="nav">

--- a/learn-plover.html
+++ b/learn-plover.html
@@ -37,6 +37,7 @@
 	<div id="drill-content">
 		<div id="answer"></div>
 		<div id="exercise"></div>
+		<div id="results"></div>
 	</div>
 
 	<div id="nav">

--- a/markov.html
+++ b/markov.html
@@ -18,6 +18,7 @@
 	<div id="drill-content">
 		<div id="answer"></div>
 		<div id="exercise"></div>
+		<div id="results"></div>
 	</div>
 
 	<div id="nav">

--- a/markov.js
+++ b/markov.js
@@ -100,9 +100,10 @@ window.onload = function() {
 	})
 	another.addEventListener('click', function(evt) {
 		evt.preventDefault();
-		let seed = Math.random().toString()
-		let rng = new_rng(seed)
-		let exercise = generateMarkovExercise(ngrams, word_count, rng)
+		let seed = Math.random().toString();
+		window.history.replaceState('', '', updateURLParameter(window.location.href, 'seed', seed));
+		let rng = new_rng(seed);
+		let exercise = generateMarkovExercise(ngrams, word_count, rng);
 		jig.exercise = exercise;
 		jig.reset();
 	})

--- a/style.css
+++ b/style.css
@@ -106,11 +106,14 @@ a, a:visited {
 	margin: 0 auto;
 	position: relative;
 }
-#exercise, #answer {
+#exercise, #answer, #results {
 	width: 100%;
 	margin-top: -0.8em;
 	line-height: 3;
 	white-space: pre-wrap;
+}
+#results {
+	line-height: 1;
 }
 #exercise {
 	position: relative;

--- a/two-key.html
+++ b/two-key.html
@@ -26,6 +26,7 @@
 	<div id="drill-content">
 		<div id="answer"></div>
 		<div id="exercise"></div>
+		<div id="results"></div>
 	</div>
 
 	<div id="nav">
@@ -52,7 +53,7 @@
 		var strokes = document.getElementById('strokes');
 		var hints = new StenoDisplay(strokes, translations, true);
 		var exercise = new TypeJig.Exercise(words);
-		var jig = new TypeJig(exercise, 'exercise', 'input', 'clock', hints);
+		var jig = new TypeJig(exercise, 'exercise', 'results', 'input', 'clock', hints);
 
 		var back = document.getElementById('back');
 		back.href = 'form.html';

--- a/type-jig.js
+++ b/type-jig.js
@@ -5,10 +5,11 @@
  * `output`, and `clock` are elements (or element ID strings).
  */
 
-function TypeJig(exercise, display, input, clock, hint) {
+function TypeJig(exercise, display, results, input, clock, hint) {
 	this.exercise = exercise;
 	this.display = documentElement(display);
 	this.input = documentElement(input);
+	this.resultsDisplay = documentElement(results);
 	this.clock = new TypeJig.Timer(documentElement(clock), exercise.seconds);
 	this.hint = hint;
 	this.errorCount = 0;
@@ -37,6 +38,7 @@ function TypeJig(exercise, display, input, clock, hint) {
 }
 
 TypeJig.prototype.reset = function() {
+	this.resultsDisplay.textContent = '';
 	if(this.exercise && !this.exercise.started) {
 		this.display.textContent = '';
 		this.getWords(0);
@@ -254,13 +256,13 @@ TypeJig.prototype.endExercise = function(seconds) {
 	else results += ', adjusting for ' + this.errorCount + ' incorrect word' + plural
 		+ ' (' + accuracy + '%) gives ' + correctedWPM + ' WPM.'
 	results = '\n\n' + results;
-	var start = this.display.textContent.length;
+	var start = this.resultsDisplay.textContent.length;
 	var end = start + results.length;
-	this.display.textContent += results;
+	this.resultsDisplay.textContent += results;
 
 	var range = document.createRange();
-	range.setStart(this.display.firstChild, start);
-	range.setEnd(this.display.firstChild, end);
+	range.setStart(this.resultsDisplay.firstChild, start);
+	range.setEnd(this.resultsDisplay.firstChild, end);
 	var rect = range.getBoundingClientRect();
 	var scroll = rect.bottom - window.innerHeight;
 	if(scroll > 0) setTimeout(function(){window.scrollBy(0, scroll)}, 2);

--- a/type-jig.js
+++ b/type-jig.js
@@ -125,7 +125,9 @@ function nextWord(words, range) {
 
 TypeJig.prototype.answerChanged = function() {
 	delete this.pendingChange;
-	if(!this.running) this.start();
+	if(!this.running && !!this.input.value.trim()) {
+		this.start();
+	}
 
 	// Get the exercise and the user's answer as arrays of
 	// words interspersed with whitespace.

--- a/util.js
+++ b/util.js
@@ -66,3 +66,30 @@ function setTheme() {
 		}
 	}
 }
+
+/**
+ * Update a URL parameter and return the new URL.
+ * Note that if handling anchors is needed in the future,
+ * this function will need to be extended. See the link below.
+ * 
+ * http://stackoverflow.com/a/10997390/11236
+ */
+function updateURLParameter(url, param, paramVal){
+    var newAdditionalURL = "";
+    var tempArray = url.split("?");
+    var baseURL = tempArray[0];
+    var additionalURL = tempArray[1];
+    var temp = "";
+    if (additionalURL) {
+        tempArray = additionalURL.split("&");
+        for (var i=0; i<tempArray.length; i++){
+            if(tempArray[i].split('=')[0] != param){
+                newAdditionalURL += temp + tempArray[i];
+                temp = "&";
+            }
+        }
+    }
+
+    var rows_txt = temp + "" + param + "=" + paramVal;
+    return baseURL + "?" + newAdditionalURL + rows_txt;
+}

--- a/util.js
+++ b/util.js
@@ -29,7 +29,7 @@ function setExercise(name, exercise, hints) {
 	var again = document.getElementById('again');
 	again.href = document.location.href;
 
-	return jig = new TypeJig(exercise, 'exercise', 'input', 'clock', hints);
+	return jig = new TypeJig(exercise, 'exercise', 'results', 'input', 'clock', hints);
 }
 
 function storageAvailable(type) {


### PR DESCRIPTION
These commits introduce a new page section called "results" (in addition to the current "answer" and "exercise"). This prevents the engine from changing the "exercise" section when an exercise is finished, which resulted in the exercise not ending when expected after a refresh-less reload. This also fixes the bug where the timer would start immediately after refreshing without waiting for input.

EDIT: Now also fixed the New Drill button not updating the URL.