### PR TITLE
Remove trimming of answer to fix cursor position

### DIFF
--- a/type-jig.js
+++ b/type-jig.js
@@ -160,7 +160,7 @@ TypeJig.prototype.answerChanged = function() {
 
 	// Get the exercise and the user's answer as arrays of
 	// words interspersed with whitespace.
-	var answer = TypeJig.wordsAndSpaces(this.input.value.trim());
+	var answer = TypeJig.wordsAndSpaces(this.input.value);
 	var exercise = this.getWords(Math.ceil(answer.length/2));
 
 	// Get the first word of the exercise, and create a range


### PR DESCRIPTION
When doing fingerspelling exercises of sentences, the cursor position is not updated after entering a space. Removing the `.trim()` of the input fixes that.

This `.trim()` was recently added with 1e4deaafcb36efb40bc3d8a45575c7b4ffba380e so I'm not sure if removing it is the right way to go.