### PR TITLE
fix "respect" to match main.json

### DIFF
--- a/plover-translations.js
+++ b/plover-translations.js
@@ -11280,7 +11280,7 @@ TypeJig.Translations.Plover = {
 	"resource": "RE/SORS",
 	"resource": ["REE/SORS","RE/SORS","ROURS"],
 	"resources": ["REE/SORS/-S","RE/SORSZ"],
-	"respect": "SPEKT",
+	"respect": "SBEKT",
 	"respectively": "SPEKT/IFL",
 	"respiration": "RECH/RAYSHN",
 	"respiratory": "RECH/TOHR",


### PR DESCRIPTION
The current translation for "respect" types "suspect"

Other possible translations:
respect: R-PT, PEBGT, SPWEBGT, RE/PEBGT, RE/SPEBGT, RAOE/SPEBGT

Local hint screenshot: 
![image](https://github.com/JoshuaGrams/steno-jig/assets/647791/0f9628cb-0750-4a2f-ba10-f2fde19dcd5e)
