### PR TITLE
remove incorrect "performance" translation

### DIFF
--- a/plover-translations.js
+++ b/plover-translations.js
@@ -9804,7 +9804,7 @@ TypeJig.Translations.Plover = {
 	"perforate": "PEFR/RAYT",
 	"perforation": "PE*FR/RAYSHN",
 	"perform": "PORM",
-	"performance": ["PER/FORM/ANS","PORMS"],
+	"performance": "PER/FORM/ANS",
 	"performative": "PORM/TIF",
 	"performed": "PORMD",
 	"performer": "PORM/E*R",


### PR DESCRIPTION
"PORMS" writes "performs"

Could also switch from "PORMS" to "PO*RMS" but since there's an accurate translation in there, I figured I'd just remove the incorrect one. Other main.json translations:

performance: PHORPLS, PO*RPLS, PORPBGS, P-FRPBS, P-FRPL/PHAPBS, PER/TPOR/PHAPBS, PER/TPORPL/APBS







